### PR TITLE
Fixed ESlint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
-import prettier from "eslint-plugin-prettier";
+import prettier from "eslint-plugin-prettier/recommended";
 
 export default tseslint.config(
   { ignores: ["dist"] },
@@ -11,7 +11,7 @@ export default tseslint.config(
     extends: [
       js.configs.recommended,
       ...tseslint.configs.recommended,
-      "plugin:prettier/recommended",
+      prettier,
     ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
@@ -21,7 +21,6 @@ export default tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
-      prettier,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@types/eslint-plugin-react-refresh": "^0.4.0",
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -1099,6 +1100,27 @@
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-plugin-react-refresh": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.0.tgz",
+      "integrity": "sha512-yrXOBjWYgBoaSnFArD7u0tctO8fjYuo0a8Kqx1gFC8uLOHMwd7or8gJvSu6i0iHRGRPlqkt7VCj7/OAovXh2AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@types/eslint-plugin-react-refresh": "^0.4.0",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
     "@types/react-syntax-highlighter": "^15.5.13",


### PR DESCRIPTION
`eslint-plugin-prettier` was not configured correctly for the new flat eslint config.
Fixed the configuration.
Added `@types/eslint-plugin-react-refresh`, as it was screaming the type not defined error in the config file. 