### PR TITLE
Close modal when clicking outside

### DIFF
--- a/src/components/SnippetModal.tsx
+++ b/src/components/SnippetModal.tsx
@@ -23,7 +23,14 @@ const SnippetModal: React.FC<Props> = ({
   useEscapeKey(handleCloseModal);
 
   return ReactDOM.createPortal(
-    <div className="modal-overlay">
+    <div
+      className="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          handleCloseModal();
+        }
+      }}
+    >
       <div className="modal | flow" data-flow-space="lg">
         <div className="modal__header">
           <h2 className="section-title">{snippet.title}</h2>


### PR DESCRIPTION
Added the ability to dismiss the snippet modal by clicking outside of it for more intuitive user experience.

Changes:
- Added click handler to modal overlay
- Modal only closes when clicking the background, not modal content