### PR TITLE
Fix category__btn shift on selection

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -465,17 +465,17 @@ abbr {
   background-color: transparent;
   border: 0;
   color: inherit;
-  border-radius: 0;
   text-align: start;
   display: inline-block;
   padding: 0.75em 1em;
   width: 100%;
   font-size: var(--fs-500);
+  border-radius: var(--br-md);
+  border: 1px solid transparent;
+  border-right: 0;
 
   &:is(:hover, :focus-visible):not(.category__btn--active) {
-    /* color: var(--text-primary); */
     background-image: var(--gradient-secondary);
-    border-radius: var(--br-md);
   }
 }
 
@@ -484,7 +484,6 @@ abbr {
   border: 1px solid var(--border-color);
   font-weight: var(--fw-bold);
   color: var(--text-dark);
-  border-radius: var(--br-md);
 }
 
 /*------------------------------------*\


### PR DESCRIPTION
So, selecting an item would shift items in the list slightly, this is because the border changes and the items are sized by their border and not content. But we need that or we'll overflow.
So this can be fixed by always having a 1px border and just hiding it.
Only changing the color of the border to something visible when needed.

Example of the border shift:
![firefox_wo8tHSTvfp](https://github.com/user-attachments/assets/4733f753-775f-4dd9-9b99-ee6f962f22c9)


<sup><sub>Oh no, 1 pixel, _**absolute horror**_</sub></sup>