### PR TITLE
Bug - Fix selector component text overflow

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -331,15 +331,22 @@ abbr {
   border-radius: var(--br-md);
   cursor: pointer;
 
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .selector__value {
   display: flex;
   gap: 0.5em;
   align-items: center;
+  width: calc(100% - 30px); /* 30px accounts for the arrow */
+}
+
+.selector__value > span {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .selector__value img {
@@ -379,6 +386,7 @@ abbr {
   list-style: none;
 
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  z-index: 1;
 }
 
 .selector__dropdown:focus-within {


### PR DESCRIPTION
# Description

- Handle overflowing text with ellipsis within the selector component for smaller screens and/or longer text lengths.

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [x] 🐞 Bug fix
- [ ] 📖 Documentation update
- [ ] 🔧 Other (please describe):

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [x] Comments are added where necessary for clarity.
- [ ] Documentation has been updated (if applicable).
- [x] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

Closes #128 

## Additional Context

<!-- Add any extra details, questions, or considerations here. -->

## Screenshots (Optional)

<!-- If your changes affect visuals, please include screenshots. -->

<details> 
<summary>Click to view screenshots</summary> 

### Before:
<img width="198" alt="Screenshot 2025-01-02 at 14 04 20" src="https://github.com/user-attachments/assets/b0f03a9c-834e-416a-845d-8bf2a70f4e17" />

### After:
<img width="222" alt="Screenshot 2025-01-02 at 14 05 46" src="https://github.com/user-attachments/assets/29e84761-72d9-4840-93d0-bdd2c000bd51" />

</details>