### PR TITLE
Bug - Change the defaultLanguage object lang prop so that it is uppercase

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -4,7 +4,7 @@ import { AppState, LanguageType, SnippetType } from "@types";
 
 // tokens
 const defaultLanguage: LanguageType = {
-  lang: "JavaScript",
+  lang: "JAVASCRIPT",
   icon: "/icons/javascript.svg",
 };
 


### PR DESCRIPTION
# Description

- Change the `defaultLanguage` object `lang` prop so that it is uppercase.

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [x] 🐞 Bug fix
- [ ] 📖 Documentation update
- [ ] 🔧 Other (please describe):

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [ ] Comments are added where necessary for clarity.
- [ ] Documentation has been updated (if applicable).
- [x] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

Closes #131 

## Additional Context

<!-- Add any extra details, questions, or considerations here. -->

## Screenshots (Optional)

<!-- If your changes affect visuals, please include screenshots. -->

<details> 
<summary>Click to view screenshots</summary> 

### Before:
![Screenshot 2025-01-02 at 17 08 26](https://github.com/user-attachments/assets/4fd7f2c4-021e-471d-8276-986055cfdba2)

### After:
![Screenshot 2025-01-02 at 17 08 15](https://github.com/user-attachments/assets/f344b826-1eb0-4cd5-81e0-e32dd2f2c8f2)

</details>