### PR TITLE
Improving error message when CRLF line endings are encountered

### DIFF
--- a/utils/snippetParser.js
+++ b/utils/snippetParser.js
@@ -16,10 +16,12 @@ function raise(issue, snippet = '') {
     return null;
 }
 
+const crlfRegex = /\r\n/gm;
 const propertyRegex = /^\s+([a-zA-Z]+):\s*(.+)/;
 const headerEndCodeStartRegex = /^\s*---\s*```.*\n/;
 const codeRegex = /^(.+)```/s
 function parseSnippet(snippetPath, text) {
+    if(crlfRegex.exec(text) !== null) return raise('Found CRLF line endings instead of LF line endings', snippetPath);
     let cursor = 0;
 
     const fromCursor = () => text.substring(cursor);


### PR DESCRIPTION
# Description

When CRLF line endings were encountered we were throwing an error that was not explicit.
This fixes that by checking that line endings are always LF.

## Type of Change

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [X] 🐞 Bug fix
- [ ] 📖 Documentation update
- [ ] 🔧 Other (please describe):