### PR TITLE
Improve Language Selector dropdowns

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -152,10 +152,10 @@ const LanguageSelector = () => {
 
   useEffect(() => {
     if (isOpen && focusedIndex >= 0) {
-      const element = document.querySelector(
-        `.selector__item:nth-child(${focusedIndex + 1})`
-      ) as HTMLElement;
-      element?.focus();
+      const elements = Array.from(document.querySelectorAll('.selector__item')) as HTMLElement[];
+      const focusableElements = elements.filter(el => el.getAttribute('tabIndex') !== '-1');
+      const element = focusableElements[focusedIndex];
+      element?.focus();   
     }
   }, [isOpen, focusedIndex]);
 
@@ -190,7 +190,7 @@ const LanguageSelector = () => {
         className={`selector__dropdown ${isOpen ? "" : " hidden"}`}
         role="listbox"
         onKeyDown={handleKeyDown}
-        tabIndex={-1}
+        tabIndex={0}
       >
         {fetchedLanguages.map((lang, index) =>
           lang.subLanguages.length > 0 ? (
@@ -206,7 +206,7 @@ const LanguageSelector = () => {
             <li
               key={lang.name}
               role="option"
-              tabIndex={-1}
+              tabIndex={0}
               onClick={() => handleSelect(lang)}
               className={`selector__item ${
                 language.name === lang.name ? "selected" : ""

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -186,43 +186,41 @@ const LanguageSelector = () => {
         </div>
         <span className="selector__arrow" />
       </button>
-      {isOpen && (
-        <ul
-          className="selector__dropdown"
-          role="listbox"
-          onKeyDown={handleKeyDown}
-          tabIndex={-1}
-        >
-          {fetchedLanguages.map((lang, index) =>
-            lang.subLanguages.length > 0 ? (
-              <SubLanguageSelector
-                key={lang.name}
-                opened={openedLanguages.includes(lang)}
-                parentLanguage={lang}
-                onDropdownToggle={handleToggleSubLanguage}
-                handleParentSelect={handleSelect}
-                afterSelect={afterSelect}
-              />
-            ) : (
-              <li
-                key={lang.name}
-                role="option"
-                tabIndex={-1}
-                onClick={() => handleSelect(lang)}
-                className={`selector__item ${
-                  language.name === lang.name ? "selected" : ""
-                } ${focusedIndex === index ? "focused" : ""}`}
-                aria-selected={language.name === lang.name}
-              >
-                <label>
-                  <img src={lang.icon} alt="" />
-                  <span>{lang.name}</span>
-                </label>
-              </li>
-            )
-          )}
-        </ul>
-      )}
+      <ul
+        className={`selector__dropdown ${isOpen ? "" : " hidden"}`}
+        role="listbox"
+        onKeyDown={handleKeyDown}
+        tabIndex={-1}
+      >
+        {fetchedLanguages.map((lang, index) =>
+          lang.subLanguages.length > 0 ? (
+            <SubLanguageSelector
+              key={lang.name}
+              opened={openedLanguages.includes(lang)}
+              parentLanguage={lang}
+              onDropdownToggle={handleToggleSubLanguage}
+              handleParentSelect={handleSelect}
+              afterSelect={afterSelect}
+            />
+          ) : (
+            <li
+              key={lang.name}
+              role="option"
+              tabIndex={-1}
+              onClick={() => handleSelect(lang)}
+              className={`selector__item ${
+                language.name === lang.name ? "selected" : ""
+              } ${focusedIndex === index ? "focused" : ""}`}
+              aria-selected={language.name === lang.name}
+            >
+              <label>
+                <img src={lang.icon} alt="" />
+                <span>{lang.name}</span>
+              </label>
+            </li>
+          )
+        )}
+      </ul>
     </div>
   );
 };

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -152,10 +152,14 @@ const LanguageSelector = () => {
 
   useEffect(() => {
     if (isOpen && focusedIndex >= 0) {
-      const elements = Array.from(document.querySelectorAll('.selector__item')) as HTMLElement[];
-      const focusableElements = elements.filter(el => el.getAttribute('tabIndex') !== '-1');
+      const elements = Array.from(
+        document.querySelectorAll(".selector__item")
+      ) as HTMLElement[];
+      const focusableElements = elements.filter(
+        (el) => el.getAttribute("tabIndex") !== "-1"
+      );
       const element = focusableElements[focusedIndex];
-      element?.focus();   
+      element?.focus();
     }
   }, [isOpen, focusedIndex]);
 

--- a/src/components/SubLanguageSelector.tsx
+++ b/src/components/SubLanguageSelector.tsx
@@ -47,7 +47,7 @@ const SubLanguageSelector = ({
     <>
       <li
         role="option"
-        tabIndex={-1}
+        tabIndex={0}
         className={`selector__item ${
           subLanguage === defaultSlugifiedSubLanguageName &&
           language.name === parentLanguage.name
@@ -82,7 +82,8 @@ const SubLanguageSelector = ({
         <li
           key={sl.name}
           role="option"
-          tabIndex={-1}
+          tabIndex={opened ? 0 : -1}
+          aria-disabled={!opened}
           className={`selector__item sublanguage__item ${opened ? "" : "hidden"} ${
             slugify(subLanguage) === slugify(sl.name) ? "selected" : ""
           }`}

--- a/src/components/SubLanguageSelector.tsx
+++ b/src/components/SubLanguageSelector.tsx
@@ -78,24 +78,23 @@ const SubLanguageSelector = ({
         </label>
       </li>
 
-      {opened &&
-        parentLanguage.subLanguages.map((sl) => (
-          <li
-            key={sl.name}
-            role="option"
-            tabIndex={-1}
-            className={`selector__item sublanguage__item ${
-              slugify(subLanguage) === slugify(sl.name) ? "selected" : ""
-            }`}
-            aria-selected={slugify(subLanguage) === slugify(sl.name)}
-            onClick={handleSubLanguageSelect(sl)}
-          >
-            <label>
-              <img src={sl.icon} alt={sl.name} />
-              <span>{sl.name}</span>
-            </label>
-          </li>
-        ))}
+      {parentLanguage.subLanguages.map((sl) => (
+        <li
+          key={sl.name}
+          role="option"
+          tabIndex={-1}
+          className={`selector__item sublanguage__item ${opened ? "" : "hidden"} ${
+            slugify(subLanguage) === slugify(sl.name) ? "selected" : ""
+          }`}
+          aria-selected={slugify(subLanguage) === slugify(sl.name)}
+          onClick={handleSubLanguageSelect(sl)}
+        >
+          <label>
+            <img src={sl.icon} alt={sl.name} />
+            <span>{sl.name}</span>
+          </label>
+        </li>
+      ))}
     </>
   );
 };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -400,7 +400,7 @@ abbr {
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid var(--clr-text-primary); /* [1] */
-  transition: transform 100ms ease;
+  transition: transform 300ms ease;
 }
 
 .selector--open .selector__arrow {
@@ -413,7 +413,7 @@ abbr {
 
   position: absolute;
   width: 100%;
-  max-height: 20rem;
+  height: 20rem;
   overflow-y: auto;
 
   background-color: var(--clr-bg-secondary);
@@ -426,10 +426,15 @@ abbr {
 
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
   z-index: 1;
+  transition: all 300ms ease;
 }
 
-.selector__dropdown:focus-within {
-  border-color: var(--clr-accent);
+.selector__dropdown.hidden {
+  border: none;
+  padding: 0;
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
 }
 
 .selector__item {
@@ -439,10 +444,19 @@ abbr {
   gap: 1rem;
   align-items: center;
   border-radius: var(--br-md);
+  transition: all 300ms ease;
 }
 
 .sublanguage__item {
+  height: 3rem;
   margin-left: 1.5rem;
+  transition: all 300ms ease;
+}
+
+.sublanguage__item.hidden {
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
 }
 
 .sublanguage__button{
@@ -462,6 +476,11 @@ abbr {
   transform: rotate(-90deg);
   transition: transform 100ms ease;
   cursor: pointer;
+  transition: all 200ms ease;
+}
+
+.sublanguage__arrow:hover {
+  border-top-color: var(--clr-accent);
 }
 
 [aria-expanded="true"] .sublanguage__arrow {
@@ -470,6 +489,10 @@ abbr {
 
 .selector__item.selected .sublanguage__arrow {
   border-top-color: var(--clr-text-tertiary);
+}
+
+.selector__item.selected .sublanguage__arrow:hover {
+  border-top-color: var(--clr-text-primary);
 }
 
 .selector__item label {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -413,7 +413,7 @@ abbr {
 
   position: absolute;
   width: 100%;
-  height: 20rem;
+  height: 50vh;
   overflow-y: auto;
 
   background-color: var(--clr-bg-secondary);
@@ -435,6 +435,19 @@ abbr {
   height: 0;
   opacity: 0;
   overflow: hidden;
+}
+
+.selector__dropdown::-webkit-scrollbar {
+  width: 8px;
+}
+
+.selector__dropdown::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 4px;
+}
+
+.selector__dropdown::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb);
 }
 
 .selector__item {


### PR DESCRIPTION
<!-- **ANY PULL REQUEST NOT FOLLOWING GUIDELINES OR NOT INCLUDING A DESCRIPTION WILL BE CLOSED !** -->

# Description

<!-- Include a summary of your changes. -->

## Type of Change

<!-- What kind of change does this pull request introduce? (Check all that apply) -->

- [ ] ✨ New snippet
- [ ] 🛠 Improvement to an existing snippet
- [x] 🐞 Bug fix
- [ ] 📖 Documentation update
- [ ] 🔧 Other (please describe):

## Checklist

<!--  Before submitting, ensure your pull request meets these requirements: -->

- [x] I have tested my code and verified it works as expected.
- [x] My code follows the style and contribution guidelines of this project.
- [x] Comments are added where necessary for clarity.
- [x] Documentation has been updated (if applicable).
- [x] There are no new warnings or errors from my changes.

## Related Issues

<!-- Link any relevant issues (use #issue-number syntax). If not, leave it empty -->

## Additional Context

This is an improvement to LanguageSelector dropdown and the SubLanguage dropdown. I have added some animations to the dropdowns using vanilla CSS. I have removed showing the dropdown using the state variable and used it to just change the CSS class. As a side effect this then renders the dropdowns and fetches SVG icons the background which also removes the weird state where the dropdown has the icons missing on the initial load (Recreated by disabling cache). (Shown below in the videos)

## Demonstrations
### Old Dropdown
https://github.com/user-attachments/assets/908c4688-2570-444a-ab31-e3cc93f5c360

### New Dropdown

https://github.com/user-attachments/assets/0454ed70-9e77-4a65-b589-7d263f0145e7




